### PR TITLE
Add RTD badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Documentation Status](https://readthedocs.org/projects/bert-etl/badge/?version=latest)](https://bert-etl.readthedocs.io/en/latest/?badge=latest)
+
 # Bert
 A microframework for simple ETL solutions
 


### PR DESCRIPTION
It lets users know you have RTD doc and also its build status on `master`.